### PR TITLE
message contains now quotes in pyls 0.18.0

### DIFF
--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -16,9 +16,9 @@ def test_plugin():
 
     assert len(diags) == 1
     diag = diags[0]
-    assert diag['message'] == 'Dict[<nothing>, <nothing>] has no attribute "append"'
-    assert diag['range']['start'] == {'line': 0, 'character': 0}
-    assert diag['range']['end'] == {'line': 0, 'character': 1}
+    assert diag['message'] == '"Dict[<nothing>, <nothing>]" has no attribute "append"'
+    assert diag['range']['start'] == {'line': 0, 'character': 1}
+    assert diag['range']['end'] == {'line': 0, 'character': 2}
 
 
 def test_parse_full_line():


### PR DESCRIPTION
Not 100% sure when this was introduced.