### PR TITLE
Fix mypy==0.700 compatibility.

### DIFF
--- a/pyls_mypy/plugin.py
+++ b/pyls_mypy/plugin.py
@@ -43,15 +43,15 @@ def parse_line(line, document=None):
 def pyls_lint(config, document):
     live_mode = config.plugin_settings('pyls_mypy').get('live_mode', True)
     if live_mode:
-        args = ('--incremental',
+        args = ['--incremental',
                 '--show-column-numbers',
                 '--follow-imports', 'silent',
-                '--command', document.source)
+                '--command', document.source]
     else:
-        args = ('--incremental',
+        args = ['--incremental',
                 '--show-column-numbers',
                 '--follow-imports', 'silent',
-                document.path)
+                document.path]
 
     report, errors, _ = mypy_api.run(args)
 


### PR DESCRIPTION
mypy.api.run method should take List[str] of args.
https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args
https://github.com/python/mypy/blob/d40990f5b91b1f06918222d1041441b7ff63f79a/mypy/api.py#L71