### PR TITLE
Fix diagnostics start position

### DIFF
--- a/pyls_mypy/plugin.py
+++ b/pyls_mypy/plugin.py
@@ -26,17 +26,17 @@ def parse_line(line, document=None):
                             document.path)
                 return None
 
-        lineno = int(lineno or 1)
-        offset = int(offset or 0)
+        lineno = int(lineno or 1) - 1  # 0-based line number
+        offset = int(offset or 1) - 1  # 0-based offset
         errno = 2
         if severity == 'error':
             errno = 1
         diag = {
             'source': 'mypy',
             'range': {
-                'start': {'line': lineno - 1, 'character': offset},
+                'start': {'line': lineno, 'character': offset},
                 # There may be a better solution, but mypy does not provide end
-                'end': {'line': lineno - 1, 'character': offset + 1}
+                'end': {'line': lineno, 'character': offset + 1}
             },
             'message': msg,
             'severity': errno

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -28,16 +28,16 @@ def test_plugin():
     assert len(diags) == 1
     diag = diags[0]
     assert diag['message'] == TYPE_ERR_MSG
-    assert diag['range']['start'] == {'line': 0, 'character': 1}
-    assert diag['range']['end'] == {'line': 0, 'character': 2}
+    assert diag['range']['start'] == {'line': 0, 'character': 0}
+    assert diag['range']['end'] == {'line': 0, 'character': 1}
 
 
 def test_parse_full_line():
     doc = Document(DOC_URI, DOC_TYPE_ERR)
     diag = plugin.parse_line(TEST_LINE, doc)
     assert diag['message'] == '"Request" has no attribute "id"'
-    assert diag['range']['start'] == {'line': 278, 'character': 8}
-    assert diag['range']['end'] == {'line': 278, 'character': 9}
+    assert diag['range']['start'] == {'line': 278, 'character': 7}
+    assert diag['range']['end'] == {'line': 278, 'character': 8}
 
 
 def test_parse_line_without_col():
@@ -56,7 +56,7 @@ def test_parse_line_without_line():
     assert diag['range']['end'] == {'line': 0, 'character': 1}
 
 
-@pytest.mark.parametrize('word,bounds', [('', (8, 9)), ('my_var', (8, 14))])
+@pytest.mark.parametrize('word,bounds', [('', (7, 8)), ('my_var', (7, 13))])
 def test_parse_line_with_context(monkeypatch, word, bounds):
     doc = Document(DOC_URI, 'DOC_TYPE_ERR')
     monkeypatch.setattr(Document, 'word_at_position', lambda *args: word)


### PR DESCRIPTION
mypy diagnostics offsets are now 1-based see https://github.com/python/mypy/issues/4475
before:
![diag_bug](https://user-images.githubusercontent.com/33235928/66072719-dfb9fe00-e555-11e9-94c7-37dbf476ab21.png)
after:
![diag_fix](https://user-images.githubusercontent.com/33235928/66072718-df216780-e555-11e9-9542-1cdea07f347f.png)
