### PR TITLE
Add option for prepending arbitrary cmd-line args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Install into the same virtualenv as pyls itself.
 
 Configuration
 -------------
+``prepend`` (default is ``[]``) list of additional command-line options to prepend
 
 ``live_mode`` (default is True) provides type checking as you type.
 
@@ -41,7 +42,8 @@ Depending on your editor, the configuration should be roughly like this:
             "pyls_mypy":
             {
                 "enabled": true,
-                "live_mode": false
+                "live_mode": false,
+                "prepend": ["--python-executable", "/tmp/foo/bin/python"]
             }
         }
     }

--- a/pyls_mypy/plugin.py
+++ b/pyls_mypy/plugin.py
@@ -72,6 +72,10 @@ def pyls_lint(config, workspace, document, is_saved):
     if settings.get('strict', False):
         args.append('--strict')
 
+    prepend = settings.get('prepend')
+    if prepend:
+        args = prepend + args
+
     report, errors, _ = mypy_api.run(args)
 
     diagnostics = []


### PR DESCRIPTION
**What**: offer users an escape hatch for corner cases

**Rationale**: people may need to adjust the options passed to mypy, and trying to accommodate everyone's needs, case-by-case, is [untenable]

**Example**: overriding options in a shared config. Suppose:
1. `pyls` and `mypy` are installed globally
2. your project runs in a virtual environment

Unfortunately, mypy requires the `python_executable` to behave correctly with this setup.
With a patch like this, a user could add something like

```yaml
lsp_overrides:pyls:plugins:pyls_mypy:prepend:
  - "--python-executable"
  - /home/me/repo/.venv/bin/python
```
to their editor's per-project dot file. (And, for more involved changes, there's always `--config-file`.)

[untenable]: https://github.com/tomv564/pyls-mypy/pull/34#issuecomment-549806367
[almost never what you want]: https://github.com/python/mypy/issues/7604#issuecomment-537708119
