### PR TITLE
Depend on python-lsp-server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Mypy plugin for PYLS
 .. image:: https://travis-ci.org/tomv564/pyls-mypy.svg?branch=master
     :target: https://travis-ci.org/tomv564/pyls-mypy
 
-This is a plugin for the Palantir's Python Language Server (https://github.com/palantir/python-language-server)
+This is a plugin for the [Python LSP Server](https://github.com/python-lsp/python-lsp-server).
 
 It, like mypy, requires Python 3.2 or newer.
 
@@ -15,7 +15,7 @@ It, like mypy, requires Python 3.2 or newer.
 Installation
 ------------
 
-Install into the same virtualenv as pyls itself.
+Install into the same virtualenv as python-lsp-server itself.
 
 ``pip install pyls-mypy``
 
@@ -34,7 +34,7 @@ Depending on your editor, the configuration should be roughly like this:
 
 ::
 
-    "pyls":
+    "pylsp":
     {
         "plugins":
         {

--- a/pyls_mypy/_version.py
+++ b/pyls_mypy/_version.py
@@ -43,7 +43,7 @@ def get_config():
     cfg.style = "pep440"
     cfg.tag_prefix = ""
     cfg.parentdir_prefix = ""
-    cfg.versionfile_source = "pyls/_version.py"
+    cfg.versionfile_source = "pylsp/_version.py"
     cfg.verbose = False
     return cfg
 

--- a/pyls_mypy/plugin.py
+++ b/pyls_mypy/plugin.py
@@ -1,7 +1,7 @@
 import re
 import logging
 from mypy import api as mypy_api
-from pyls import hookimpl
+from pylsp import hookimpl
 
 line_pattern = r"([^:]+):(?:(\d+):)?(?:(\d+):)? (\w+): (.*)"
 
@@ -53,7 +53,7 @@ def parse_line(line, document=None):
 
 
 @hookimpl
-def pyls_lint(config, workspace, document, is_saved):
+def pylsp_lint(config, workspace, document, is_saved):
     settings = config.plugin_settings('pyls_mypy')
     live_mode = settings.get('live_mode', True)
     if live_mode:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future;python_version < '3'
 flake8
 configparser
-python-language-server
+python-lsp-server
 mypy;python_version >= '3.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,17 @@
 [metadata]
 name = pyls-mypy
 author = Tom van Ommeren
-description = Mypy linter for the Python Language Server
+description = Mypy linter for the Python LSP Server
 url = https://github.com/tomv564/pyls-mypy
 long_description = file: README.rst
 
 [options]
 packages = find:
-install_requires = python-language-server; mypy
+install_requires = python-lsp-server; mypy
 
 
 [options.entry_points]
-pyls = pyls_mypy = pyls_mypy.plugin
+pylsp = pyls_mypy = pyls_mypy.plugin
 
 [options.extras_require]
 test =

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,6 +1,7 @@
 import pytest
 
-from pyls.workspace import Document
+from pylsp.workspace import Document
+
 from pyls_mypy import plugin
 
 DOC_URI = __file__


### PR DESCRIPTION
[Palantir's python-language-server](https://github.com/palantir/python-language-server) is now unmaintained. [python-lsp-server](https://github.com/python-lsp/python-lsp-server) is a community-maintained fork.

Fixes #51.